### PR TITLE
Add confocal images

### DIFF
--- a/src/tye_lab_to_nwb/neurotensin_valence/images/__init__.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/images/__init__.py
@@ -1,0 +1,1 @@
+from .neurotensinconfocalimagesdatainterface import NeurotensinConfocalImagesInterface

--- a/src/tye_lab_to_nwb/neurotensin_valence/images/neurotensinconfocalimagesdatainterface.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/images/neurotensinconfocalimagesdatainterface.py
@@ -64,7 +64,7 @@ class NeurotensinConfocalImagesInterface(BaseDataInterface):
         depth_range /= 1e6  # nm to m
         metadata_from_file["Images"] = dict(
             name=self.oif.filesystem.name,
-            description=f"The {location} confocal images from {software_name} version {software_version} exctracted from {image_file_name}.",
+            description=f"The {location} confocal images from {software_name} version {software_version} extracted from {image_file_name}.",
         )
 
         images_metadata = []

--- a/src/tye_lab_to_nwb/neurotensin_valence/images/neurotensinconfocalimagesdatainterface.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/images/neurotensinconfocalimagesdatainterface.py
@@ -1,0 +1,115 @@
+import re
+from datetime import datetime
+from typing import Optional
+
+import numpy as np
+from hdmf.backends.hdf5 import H5DataIO
+from neuroconv.basedatainterface import BaseDataInterface
+from neuroconv.tools.nwb_helpers import make_or_load_nwbfile
+from neuroconv.utils import FilePathType, dict_deep_update
+from oiffile import OifFile
+from pynwb import NWBFile
+from pynwb.base import Images
+from pynwb.image import GrayscaleImage
+
+
+class NeurotensinConfocalImagesInterface(BaseDataInterface):
+    """Primary interface for converting confocal images for the Neurotensin experiment."""
+
+    def __init__(
+        self,
+        file_path: FilePathType,
+        verbose: bool = True,
+    ):
+        """
+        Interface for converting confocal images from Olympus FluoView.
+
+        Parameters
+        ----------
+        file_path : FilePathType
+            path to the Olympus Image File (.OIF).
+        verbose: bool, default: True
+            controls verbosity.
+        """
+        self.verbose = verbose
+        self.oif = OifFile(file_path)
+
+        super().__init__(file_path=file_path)
+
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+
+        metadata_from_file = dict()
+        settings = self.oif.filesystem.settings
+
+        # Add session_start_time
+        session_start_time = settings["Acquisition Parameters Common"]["ImageCaputreDate"]
+        metadata["NWBFile"].update(session_start_time=datetime.fromisoformat(session_start_time))
+
+        image_file_name = settings.name  # 'H28PVT_40x.oif'
+        subject_id, location = re.search("([a-zA-Z]+\d+)([^_]+)", image_file_name).groups()
+        metadata_from_file["Subject"] = dict(subject_id=subject_id)
+
+        software_name = settings["Version Info"]["SystemName"]  # 'FLUOVIEW FV1000'
+        software_version = settings["Version Info"]["FileVersion"]  # '1.2.6.0'
+        # num_axis = settings["Axis Parameter Common"]["AxisCount"]  # 4
+        # axis_order = self.oif.axes  # 'ZCYX' depth, ch, width, height
+
+        depth_settings = settings["Axis 3 Parameters Common"]
+        depth_range = np.arange(
+            depth_settings["StartPosition"],
+            depth_settings["EndPosition"] + depth_settings["Interval"],
+            depth_settings["Interval"],
+        )
+        depth_range /= 1e6  # nm to m
+        metadata_from_file["Images"] = dict(
+            name=self.oif.filesystem.name,
+            description=f"The {location} confocal images from {software_name} version {software_version} exctracted from {image_file_name}.",
+        )
+
+        images_metadata = []
+        for channel_num, depth_num in self.oif.series[0].indices:
+            image_name = f"GrayScaleImage{channel_num+1}Depth{depth_num+1}"
+            image_description = f"The image intensity from {location} region at {depth_range[depth_num]} meters depth."
+            images_metadata.append(dict(name=image_name, description=image_description))
+
+        metadata_from_file["Images"].update(images=images_metadata)
+        metadata = dict_deep_update(metadata, metadata_from_file)
+        return metadata
+
+    def align_timestamps(self, aligned_timestamps: np.ndarray):
+        pass
+
+    def get_original_timestamps(self) -> np.ndarray:
+        pass
+
+    def get_timestamps(self) -> np.ndarray:
+        pass
+
+    def run_conversion(
+        self,
+        nwbfile_path: Optional[str] = None,
+        nwbfile: Optional[NWBFile] = None,
+        metadata: Optional[dict] = None,
+        overwrite: bool = False,
+        **conversion_options,
+    ):
+        with make_or_load_nwbfile(
+            nwbfile_path=nwbfile_path, nwbfile=nwbfile, metadata=metadata, overwrite=overwrite, verbose=self.verbose
+        ) as nwbfile_out:
+            images = Images(name=metadata["Images"]["name"], description=metadata["Images"]["description"])
+            file_list = list(self.oif.series[0])
+
+            for file_ind, file in enumerate(file_list):
+                image = self.oif.series[0].imread(file)
+                image_metadata = metadata["Images"]["images"][file_ind]
+
+                images.add_image(
+                    GrayscaleImage(
+                        name=image_metadata["name"],
+                        data=H5DataIO(image.T, compression=True),
+                        description=image_metadata["description"],
+                    )
+                )
+
+            nwbfile_out.add_acquisition(images)

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
@@ -1,8 +1,6 @@
 """Primary script to run to convert an entire session for of data using the NWBConverter."""
 from pathlib import Path
-import datetime
 from typing import Optional
-from zoneinfo import ZoneInfo
 
 from neuroconv.utils import load_dict_from_file, dict_deep_update, FilePathType
 
@@ -14,8 +12,8 @@ def session_to_nwb(
     output_dir_path: FilePathType,
     plexon_file_path: FilePathType,
     events_file_path: FilePathType,
-    events_conversion_options: Optional[dict] = None,
     histology_file_path: FilePathType,
+    events_conversion_options: Optional[dict] = None,
     pose_estimation_source_data: Optional[dict] = None,
     pose_estimation_conversion_options: Optional[dict] = None,
     stub_test: bool = False,
@@ -131,6 +129,7 @@ if __name__ == "__main__":
         data_dir_path=data_dir_path,
         output_dir_path=output_dir_path,
         events_file_path=events_mat_file_path,
+        histology_file_path=histology_file_path,
         events_conversion_options=events_conversion_options,
         plexon_file_path=plexon_file_path,
         pose_estimation_source_data=pose_estimation_source_data,

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
@@ -13,6 +13,7 @@ def session_to_nwb(
     data_dir_path: FilePathType,
     output_dir_path: FilePathType,
     plexon_file_path: FilePathType,
+    histology_file_path: FilePathType,
     pose_estimation_source_data: Optional[dict] = None,
     pose_estimation_conversion_options: Optional[dict] = None,
     stub_test: bool = False,
@@ -33,6 +34,9 @@ def session_to_nwb(
     # Add Behavior
     source_data.update(dict(Behavior=pose_estimation_source_data))
     conversion_options.update(dict(Behavior=pose_estimation_conversion_options))
+
+    # Add confocal images
+    source_data.update(dict(Images=dict(file_path=histology_file_path)))
 
     converter = NeurotensinValenceNWBConverter(source_data=source_data)
 
@@ -89,6 +93,9 @@ if __name__ == "__main__":
         labeled_video_file_path="H028Disc4DLC_resnet50_Hao_MedPC_ephysFeb9shuffle1_800000_labeled.mp4",
         edges=edges,
     )
+
+    # The file path to the Olympus Image File (.oif)
+    histology_file_path = "Hao_NWB/histo/H28PVT_40x.oif"
 
     output_dir_path = Path("Hao_NWB/nwbfiles")
     stub_test = False

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
@@ -12,7 +12,7 @@ def session_to_nwb(
     output_dir_path: FilePathType,
     plexon_file_path: FilePathType,
     events_file_path: FilePathType,
-    histology_file_path: FilePathType,
+    histology_source_data: dict[str, str],
     events_conversion_options: Optional[dict] = None,
     pose_estimation_source_data: Optional[dict] = None,
     pose_estimation_conversion_options: Optional[dict] = None,
@@ -57,7 +57,7 @@ def session_to_nwb(
     )
 
     # Add confocal images
-    source_data.update(dict(Images=dict(file_path=histology_file_path)))
+    source_data.update(dict(Images=histology_source_data))
 
     converter = NeurotensinValenceNWBConverter(source_data=source_data)
 
@@ -119,8 +119,11 @@ if __name__ == "__main__":
     events_column_mappings = dict(onset="start_time", offset="stop_time")
     events_conversion_options = dict(column_name_mapping=events_column_mappings)
 
-    # The file path to the Olympus Image File (.oif)
-    histology_file_path = "Hao_NWB/histo/H28PVT_40x.oif"
+    # Add histology source data
+    histology_source_data = dict(
+        file_path="Hao_NWB/histo/H28PVT_40x.oif",  # The file path to the Olympus Image File (.oif)
+        composite_tif_file_path="Hao_NWB/histo/H28_MAX_Composite.tif",  # The file path to the aggregated confocal images in TIF format.
+    )
 
     output_dir_path = Path("Hao_NWB/nwbfiles")
     stub_test = False
@@ -129,7 +132,7 @@ if __name__ == "__main__":
         data_dir_path=data_dir_path,
         output_dir_path=output_dir_path,
         events_file_path=events_mat_file_path,
-        histology_file_path=histology_file_path,
+        histology_source_data=histology_source_data,
         events_conversion_options=events_conversion_options,
         plexon_file_path=plexon_file_path,
         pose_estimation_source_data=pose_estimation_source_data,

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_requirements.txt
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_requirements.txt
@@ -1,2 +1,3 @@
 neuroconv
 ndx_pose>=0.1.1
+oiffile==2022.9.29

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valencenwbconverter.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valencenwbconverter.py
@@ -12,7 +12,6 @@ from tye_lab_to_nwb.neurotensin_valence.behavior import (
     NeurotensinDeepLabCutInterface,
     NeurotensinEventsInterface,
 )
-from tye_lab_to_nwb.neurotensin_valence.behavior import NeurotensinDeepLabCutInterface
 from tye_lab_to_nwb.neurotensin_valence.images import NeurotensinConfocalImagesInterface
 
 
@@ -24,7 +23,6 @@ class NeurotensinValenceNWBConverter(NWBConverter):
         Sorting=PlexonSortingInterface,
         PoseEstimation=NeurotensinDeepLabCutInterface,
         Events=NeurotensinEventsInterface,
-        Behavior=NeurotensinDeepLabCutInterface,
         Images=NeurotensinConfocalImagesInterface,
     )
 

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valencenwbconverter.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valencenwbconverter.py
@@ -9,6 +9,7 @@ from neuroconv.datainterfaces import (
 )
 
 from tye_lab_to_nwb.neurotensin_valence.behavior import NeurotensinDeepLabCutInterface
+from tye_lab_to_nwb.neurotensin_valence.images import NeurotensinConfocalImagesInterface
 
 
 class NeurotensinValenceNWBConverter(NWBConverter):
@@ -18,6 +19,7 @@ class NeurotensinValenceNWBConverter(NWBConverter):
         Recording=OpenEphysRecordingInterface,
         Sorting=PlexonSortingInterface,
         Behavior=NeurotensinDeepLabCutInterface,
+        Images=NeurotensinConfocalImagesInterface,
     )
 
     def get_metadata_schema(self) -> dict:


### PR DESCRIPTION
The histology data is in Olympus Image File format which includes a main setting file (.oif) and an associated directory with data and setting files (.tif, .bmp, .txt, .pty, .roi, and .lut).

I'm using the [oiffile](https://pypi.org/project/oiffile/) package to load the image and metadata to write the images to NWB.
Currently I'm using the name and version of the software (e.g. FLUOVIEW FV1000, 1.2.6.0) and the depth information.
Currently I'm creating an `Images` container and adding a `GrayscaleImage` per file (24 files in total) with a name and description using the extracted metadata. 

@CodyCBakerPhD 
I'm not sure if there is an extension for storing all relevant metadata that can be extracted from the setting files, if not, in the future it might be worth creating one. 