### PR TITLE
Disable `stub_test`

### DIFF
--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_all_sessions.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_all_sessions.py
@@ -74,7 +74,7 @@ def parallel_convert_sessions(
                         labeled_video_file_path=row["behavior_labeled_movie_file_path"],
                         confocal_images_oif_file_path=row["confocal_images_oif_file_path"],
                         confocal_images_composite_tif_file_path=row["confocal_images_composite_tif_file_path"],
-                        stub_test=True,
+                        stub_test=False,
                     )
                 )
             for future in as_completed(futures):

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_requirements.txt
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/catalystneuro/neuroconv@35d4d5c809da32d97e9101395be85f5575b73ba3
+-e git+https://github.com/catalystneuro/neuroconv@1357319ffe454fda82824dfec6af6d0f2854ed3f#egg=neuroconv
 neuroconv[openephys,plexon,video]
 ndx_pose>=0.1.1
 oiffile==2022.9.29


### PR DESCRIPTION
Left stub_test=True while debugging, this PR disables it. Also updates the commit hash for neuroconv to include the update for OpenEphysLegacyInterface (https://github.com/catalystneuro/neuroconv/pull/410)