### PR TITLE
Updates in Hao conversion for Laurel

### DIFF
--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_all_sessions.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_all_sessions.py
@@ -48,7 +48,7 @@ def parallel_convert_sessions(
 
     max_workers = calculate_number_of_cpu(requested_cpu=num_parallel_jobs)
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        with tqdm(total=len(config["ecephys_folder_path"]), position=0, leave=False) as progress_bar:
+        with tqdm(total=len(config), position=0, leave=False) as progress_bar:
             futures = []
 
             for row_ind, row in config.iterrows():
@@ -63,13 +63,15 @@ def parallel_convert_sessions(
                     executor.submit(
                         session_to_nwb,
                         nwbfile_path=row["nwbfile_path"],
-                        ecephys_recording_folder_path=row["ecephys_folder_path"],
                         # optional parameters
+                        ecephys_recording_folder_path=row["ecephys_folder_path"],
                         subject_metadata=subject_metadata,
                         plexon_file_path=row["plexon_file_path"],
                         events_file_path=row["events_mat_file_path"],
                         pose_estimation_file_path=row["pose_estimation_csv_file_path"],
                         pose_estimation_config_file_path=row["pose_estimation_pickle_file_path"],
+                        pose_estimation_sampling_rate=row["pose_estimation_sampling_rate"],
+                        session_start_time=row["session_start_time"],
                         original_video_file_path=row["behavior_movie_file_path"],
                         labeled_video_file_path=row["behavior_labeled_movie_file_path"],
                         confocal_images_oif_file_path=row["confocal_images_oif_file_path"],
@@ -89,5 +91,5 @@ if __name__ == "__main__":
 
     parallel_convert_sessions(
         excel_file_path=excel_file_path,
-        num_parallel_jobs=3,  # defines the number of sessions that will be converted in parallel.
+        num_parallel_jobs=1,  # defines the number of sessions that will be converted in parallel.
     )

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_all_sessions.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_all_sessions.py
@@ -91,5 +91,5 @@ if __name__ == "__main__":
 
     parallel_convert_sessions(
         excel_file_path=excel_file_path,
-        num_parallel_jobs=1,  # defines the number of sessions that will be converted in parallel.
+        num_parallel_jobs=3,  # defines the number of sessions that will be converted in parallel.
     )

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
@@ -71,7 +71,9 @@ def session_to_nwb(
 
     # Add Recording
     if ecephys_recording_folder_path:
-        source_data.update(dict(Recording=dict(folder_path=str(ecephys_recording_folder_path), stream_name="Signals CH")))
+        source_data.update(
+            dict(Recording=dict(folder_path=str(ecephys_recording_folder_path), stream_name="Signals CH"))
+        )
         conversion_options.update(dict(Recording=dict(stub_test=stub_test)))
 
     # Add Sorting (optional)

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Optional, Dict
 from warnings import warn
 
+from dateutil import parser
+
 from neuroconv.utils import (
     load_dict_from_file,
     dict_deep_update,
@@ -18,12 +20,14 @@ from tye_lab_to_nwb.neurotensin_valence import NeurotensinValenceNWBConverter
 
 def session_to_nwb(
     nwbfile_path: FilePathType,
-    ecephys_recording_folder_path: FolderPathType,
+    ecephys_recording_folder_path: Optional[FolderPathType] = None,
     subject_metadata: Optional[Dict[str, str]] = None,
     plexon_file_path: Optional[FilePathType] = None,
     events_file_path: Optional[FilePathType] = None,
     pose_estimation_file_path: Optional[FilePathType] = None,
     pose_estimation_config_file_path: Optional[FilePathType] = None,
+    pose_estimation_sampling_rate: Optional[float] = None,
+    session_start_time: Optional[str] = None,
     original_video_file_path: Optional[FilePathType] = None,
     labeled_video_file_path: Optional[FilePathType] = None,
     confocal_images_oif_file_path: Optional[FilePathType] = None,
@@ -62,14 +66,13 @@ def session_to_nwb(
         Default is to write the whole ecephys recording and plexon data to the file.
     """
 
-    ecephys_recording_folder_path = Path(ecephys_recording_folder_path)
-
     source_data = dict()
     conversion_options = dict()
 
     # Add Recording
-    source_data.update(dict(Recording=dict(folder_path=str(ecephys_recording_folder_path), stream_name="Signals CH")))
-    conversion_options.update(dict(Recording=dict(stub_test=stub_test)))
+    if ecephys_recording_folder_path:
+        source_data.update(dict(Recording=dict(folder_path=str(ecephys_recording_folder_path), stream_name="Signals CH")))
+        conversion_options.update(dict(Recording=dict(stub_test=stub_test)))
 
     # Add Sorting (optional)
     if plexon_file_path:
@@ -102,14 +105,16 @@ def session_to_nwb(
 
     # Add pose estimation (optional)
     pose_estimation_source_data = dict()
+    pose_estimation_conversion_options = dict()
     if pose_estimation_file_path:
         pose_estimation_source_data.update(file_path=str(pose_estimation_file_path))
         if pose_estimation_config_file_path:
             pose_estimation_source_data.update(config_file_path=str(pose_estimation_config_file_path))
+        elif pose_estimation_sampling_rate is not None:
+            pose_estimation_conversion_options.update(rate=float(pose_estimation_sampling_rate))
 
         source_data.update(dict(PoseEstimation=pose_estimation_source_data))
 
-    pose_estimation_conversion_options = dict()
     if original_video_file_path:
         pose_estimation_conversion_options.update(original_video_file_path=original_video_file_path)
         source_data.update(
@@ -149,15 +154,25 @@ def session_to_nwb(
         metadata = dict_deep_update(metadata, dict(Subject=subject_metadata))
 
     if "session_id" not in metadata["NWBFile"]:
-        ecephys_folder_name = ecephys_recording_folder_path.name
-        session_id = ecephys_folder_name.replace(" ", "").replace("_", "-")
+        if ecephys_recording_folder_path:
+            ecephys_recording_folder_path = Path(ecephys_recording_folder_path)
+            ecephys_folder_name = ecephys_recording_folder_path.name
+            session_id = ecephys_folder_name.replace(" ", "").replace("_", "-")
+        elif pose_estimation_file_path:
+            session_id = Path(pose_estimation_file_path).name.replace(" ", "").replace("_", "-")
+        else:
+            session_id = Path(nwbfile_path).stem.replace(" ", "").replace("_", "-")
+
         metadata["NWBFile"].update(session_id=session_id)
 
-    nwbfile_path = Path(nwbfile_path)
-    nwbfile_name = nwbfile_path.name
-    if stub_test:
-        nwbfile_path = nwbfile_path.parent / "nwb_stub" / nwbfile_name
-    nwbfile_path.parent.mkdir(parents=True, exist_ok=True)
+    if "session_start_time" not in metadata["NWBFile"]:
+        if session_start_time is None:
+            raise ValueError(
+                "When ecephys recording is not specified the start time of the session must be provided."
+                "Specify session_start_time in YYYY-MM-DDTHH:MM:SS format (e.g. 2023-08-21T15:30:00)."
+            )
+        session_start_time_dt = parser.parse(session_start_time)
+        metadata["NWBFile"].update(session_start_time=session_start_time_dt)
 
     try:
         # Run conversion
@@ -166,6 +181,7 @@ def session_to_nwb(
         )
 
         # Run inspection for nwbfile
+        nwbfile_path = Path(nwbfile_path)
         results = list(inspect_nwb(nwbfile_path=nwbfile_path))
         report_path = nwbfile_path.parent / f"{nwbfile_path.stem}_inspector_result.txt"
         save_report(
@@ -174,6 +190,7 @@ def session_to_nwb(
                 results,
                 levels=["importance", "file_path"],
             ),
+            overwrite=True,
         )
     except Exception as e:
         with open(f"{nwbfile_path.parent}/{nwbfile_path.stem}_error_log.txt", "w") as f:
@@ -208,6 +225,13 @@ if __name__ == "__main__":
     pose_estimation_config_file_path = (
         "Hao_NWB/behavior/freezing_DLC/H028Disc4DLC_resnet50_Hao_MedPC_ephysFeb9shuffle1_800000includingmetadata.pickle"
     )
+    # If the pickle file is not available the sampling rate in units of Hz for the behavior data must be provided.
+    pose_estimation_sampling_rate = None
+
+    # For sessions where only the pose estimation data is available the start time of the session must be provided.
+    # The session_start_time in YYYY-MM-DDTHH:MM:SS format (e.g. 2023-08-21T15:30:00).
+    session_start_time = None
+
     # The file path that points to the behavior movie file, optional
     # original_video_file_path = None
     original_video_file_path = "H028Disc4.mkv"
@@ -223,14 +247,14 @@ if __name__ == "__main__":
     confocal_images_composite_tif_file_path = "Hao_NWB/histo/H28_MAX_Composite.tif"
 
     # The file path where the NWB file will be created.
-    nwbfile_path = Path("Hao_NWB/nwbfiles/test.nwb")
+    nwbfile_path = Path("/Volumes/t7-ssd/Hao_NWB/nwbfiles/test.nwb")
 
     # For faster conversion, stub_test=True would only write a subset of ecephys and plexon data.
     # When running a full conversion, use stub_test=False.
     stub_test = False
 
     # subject metadata (optional)
-    subject_metadata = dict(sex="M")
+    subject_metadata = dict(sex="M", subject_id="H28")
 
     session_to_nwb(
         nwbfile_path=nwbfile_path,
@@ -240,6 +264,8 @@ if __name__ == "__main__":
         events_file_path=events_mat_file_path,
         pose_estimation_file_path=pose_estimation_file_path,
         pose_estimation_config_file_path=pose_estimation_config_file_path,
+        pose_estimation_sampling_rate=pose_estimation_sampling_rate,
+        session_start_time=session_start_time,
         original_video_file_path=original_video_file_path,
         labeled_video_file_path=labeled_video_file_path,
         confocal_images_oif_file_path=confocal_images_oif_file_path,

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
@@ -192,7 +192,6 @@ def session_to_nwb(
                 results,
                 levels=["importance", "file_path"],
             ),
-            overwrite=True,
         )
     except Exception as e:
         with open(f"{nwbfile_path.parent}/{nwbfile_path.stem}_error_log.txt", "w") as f:

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
@@ -249,14 +249,14 @@ if __name__ == "__main__":
     confocal_images_composite_tif_file_path = "Hao_NWB/histo/H28_MAX_Composite.tif"
 
     # The file path where the NWB file will be created.
-    nwbfile_path = Path("/Volumes/t7-ssd/Hao_NWB/nwbfiles/test.nwb")
+    nwbfile_path = Path("Hao_NWB/nwbfiles/test.nwb")
 
     # For faster conversion, stub_test=True would only write a subset of ecephys and plexon data.
     # When running a full conversion, use stub_test=False.
     stub_test = False
 
     # subject metadata (optional)
-    subject_metadata = dict(sex="M", subject_id="H28")
+    subject_metadata = dict(sex="M")
 
     session_to_nwb(
         nwbfile_path=nwbfile_path,

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_notes.md
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_notes.md
@@ -1,1 +1,42 @@
-# Notes concerning the neurotensin_valence conversion
+# Conversion notes
+
+# Run conversion for multiple sessions in parallel
+
+The `neurotensin_valence_convert_all_sessions.py` conversion script takes an Excel (.xlsx) file as an input
+which contain all the necessary information to convert each session. The number of rows in the file
+correspond to the number of sessions that will be converted.
+
+The columns in the selected Excel (.xlsx) file should be named as:
+- "`ecephys_folder_path`" : The path that points to the folder where the OpenEphys (.continuous) files are located.
+- "`nwbfile_path`": The file path where the NWB file will be created. (e.g. "test.nwb")
+- "`plexon_file_path`": The path that points to the Plexon file
+- "`events_mat_file_path`": The file path that points to the events.mat file
+- "`pose_estimation_csv_file_path`": The file path that points to the DLC output (.CSV file)
+- "`pose_estimation_pickle_file_path`": The file path that points to the DLC configuration file (.pickle file), optional
+- "`pose_estimation_sampling_rate`": If the pickle file is not available the sampling rate in units of Hz (e.g. 30.0) for the behavior data must be provided.
+- "`session_start_time`": For sessions where only the pose estimation data is available the start time of the session must be provided. The session_start_time in YYYY-MM-DDTHH:MM:SS format (e.g. 2023-08-21T15:30:00).
+- "`behavior_movie_file_path`": The file path that points to the behavior movie file
+- "`behavior_labeled_movie_file_path`": The file path that points to the labeled behavior movie file
+- "`confocal_images_oif_file_path`": The file path to the Olympus Image File (.oif)
+- "`confocal_images_composite_tif_file_path`": The file path to the aggregated confocal images in TIF format.
+
+Example with subject metadata columns (e.g. `subject_id`, `age`, `sex`, `genotype`, `strain`)
+
+| ecephys_folder_path               | plexon_file_path                                               | events_mat_file_path                                       | pose_estimation_csv_file_path                             | pose_estimation_pickle_file_path                        | confocal_images_oif_file_path | confocal_images_composite_tif_file_path | behavior_movie_file_path | behavior_labeled_movie_file_path | nwbfile_path | subject_id | age | sex | genotype | strain | session_start_time      | pose_estimation_sampling_rate |
+|-----------------------------------| -------------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------- | ----------------------------------------------------- | ---------------------------- | -------------------------------------- | ------------------------ | ---------------------------------- | ------------ | ---------- | --- | --- | -------- | ------ | ------------------------ | ---------------------------- |
+| H28_2020-02-19_14-27-39_Disc3_20k | H28_2020-02-19_14-27-39_Disc3_20k/0028_20200221_20k.plx       | H28_2020-02-19_14-27-39_Disc3_20k/0028_20200221_20k_events.mat | 28_Disc4DLC_resnet50_Hao_MedPC_ephysFeb9shuffle1_800000.csv | H028Disc4DLC_resnet50_Hao_MedPC_ephysFeb9shuffle1_800000includingmetadata.pickle | H31PVT_40x.oif               | H31_MAX_Composite.tif                | H028Disc4.mkv            |                                    | H28_Disc4.nwb | H28        | P7D | M   |          |        |                        |                              |
+|                                   |                                                                |                                                              | 32_Disc4DLC_resnet50_Hao_MedPC_ephysFeb11shuffle1_800000.csv |                                                                   |                            |                                      |                        |                                  | H32_Disc4.nwb | H32        | P8D | M   |          |        | 2023-08-21T15:30:00     | 30.0                         |
+
+
+
+```python
+from tye_lab_to_nwb.neurotensin_valence.neurotensin_valence_convert_all_sessions import parallel_convert_sessions
+
+# The file path to the conversion settings for each session
+excel_file_path = "/Volumes/t7-ssd/Hao_NWB/session_config.xlsx"
+
+parallel_convert_sessions(
+    excel_file_path=excel_file_path,
+    num_parallel_jobs=3,  # defines the number of sessions that will be converted in parallel.
+)
+```


### PR DESCRIPTION
- Enable running conversion for a session without ecephys recording data
- For cases when only the pose estimation CSV data is available (contains only the pose series) the start time of the session (session_start_time) needs to be specified and the sampling rate in units of Hz.
-  Added `src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_notes.md` to document how the excel file columns for the parallel run is expected to be named

The conversion was tested in a fresh `conda` environment (python=3.9) with installing `neurotensin_valence_requirements.txt`
