### PR TITLE
Add ASt `ophys` pipeline

### DIFF
--- a/src/tye_lab_to_nwb/ast_ophys/ast_ophysnwbconverter.py
+++ b/src/tye_lab_to_nwb/ast_ophys/ast_ophysnwbconverter.py
@@ -1,0 +1,58 @@
+from typing import Optional
+
+from neuroconv.converters import MiniscopeConverter
+
+from neuroconv import NWBConverter
+from pynwb import NWBFile
+
+
+from tye_lab_to_nwb.ast_ophys.interfaces import (
+    CnmfeMatlabSegmentationSegmentationInterface,
+    MotionCorrectedMiniscopeImagingInterface,
+    ProcessedMiniscopeImagingInterface,
+)
+
+
+class AStOphysNWBConverter(NWBConverter):
+    """Primary conversion class for the ASt optical imaging dataset."""
+
+    data_interface_classes = dict(
+        RawImaging=MiniscopeConverter,
+        ProcessedImaging=ProcessedMiniscopeImagingInterface,
+        MotionCorrectedImaging=MotionCorrectedMiniscopeImagingInterface,
+        Segmentation=CnmfeMatlabSegmentationSegmentationInterface,
+    )
+
+    def run_conversion(
+        self,
+        nwbfile_path: Optional[str] = None,
+        nwbfile: Optional[NWBFile] = None,
+        metadata: Optional[dict] = None,
+        overwrite: bool = False,
+        conversion_options: Optional[dict] = None,
+    ):
+        # TODO: remove this part if
+        # if "RawImaging" in self.data_interface_objects:
+        #     miniscope_converter = self.data_interface_objects["RawImaging"]
+        #     imaging_interface = miniscope_converter.data_interface_objects["MiniscopeImaging"]
+
+        if "MotionCorrectedImaging" in self.data_interface_objects:
+            motion_corrected_imaging_interface = self.data_interface_objects["MotionCorrectedImaging"]
+            # TODO: clarify rate (segmentation data and raw imaging is fs 15, but opencv frame rate for processed is 30.0)
+            motion_corrected_imaging_interface.imaging_extractor._sampling_frequency = 30.0
+
+        if "ProcessedImaging" in self.data_interface_objects:
+            processed_imaging_interface = self.data_interface_objects["ProcessedImaging"]
+            # TODO: clarify rate
+            processed_imaging_interface.imaging_extractor._sampling_frequency = 30.0
+
+        # Update imaging plane location
+        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
+        imaging_plane_metadata.update(location="ASt")
+
+        super().run_conversion(
+            nwbfile_path=nwbfile_path,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            conversion_options=conversion_options,
+        )

--- a/src/tye_lab_to_nwb/ast_ophys/convert_session.py
+++ b/src/tye_lab_to_nwb/ast_ophys/convert_session.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+from typing import Optional, List
+
+from neuroconv.utils import (
+    FilePathType,
+    FolderPathType,
+)
+from tye_lab_to_nwb.ast_ophys.ast_ophysnwbconverter import AStOphysNWBConverter
+
+
+def session_to_nwb(
+    nwbfile_path: FilePathType,
+    miniscope_folder_path: Optional[FolderPathType] = None,
+    processed_miniscope_avi_file_path: Optional[FilePathType] = None,
+    motion_corrected_mat_file_path: Optional[FilePathType] = None,
+    timestamps_mat_file_path: Optional[FilePathType] = None,
+    reward_trials_indices: Optional[List[int]] = None,
+    segmentation_mat_file_path: Optional[FilePathType] = None,
+    stub_test: Optional[bool] = False,
+):
+    """
+    Converts a single session to NWB.
+
+    Parameters
+    ----------
+    nwbfile_path : FilePathType
+        The file path to the NWB file that will be created.
+    miniscope_folder_path: FolderPathType, optional
+        The path that points to the folder where the raw Miniscope data is located.
+    motion_corrected_mat_file_path: FilePathType, optional
+        The path to the .mat file that contains the motion corrected imaging data.
+    timestamps_mat_file_path: FilePathType, optional
+        The path to the .mat file that contains the timestamps for the trials data.
+    reward_trials_indices: List, optional
+        The list that denotes which trial indices are reward trials.
+        e.g. [1, 3, 6, 9, 10, 12, 13, 15, 16, 20, 23, 24, 27, 28, 30]
+    stub_test: bool, optional
+        For testing purposes, when stub_test=True only writes a subset of ecephys and plexon data.
+        Default is to write the whole ecephys recording and plexon data to the file.
+    """
+
+    source_data = dict()
+    conversion_options = dict()
+
+    # Add raw Miniscope imaging
+    if miniscope_folder_path:
+        imaging_folder_path = Path(miniscope_folder_path)
+        source_data.update(dict(RawImaging=dict(folder_path=str(imaging_folder_path))))
+        conversion_options.update(dict(RawImaging=dict(stub_test=stub_test)))
+
+    # Add processed Miniscope imaging
+    if processed_miniscope_avi_file_path:
+        source_data.update(
+            dict(
+                ProcessedImaging=dict(
+                    file_path=str(processed_miniscope_avi_file_path),
+                    timestamps_file_path=str(timestamps_mat_file_path),
+                )
+            )
+        )
+        conversion_options.update(dict(ProcessedImaging=dict(stub_test=stub_test)))
+
+    # Add motion corrected imaging
+    if motion_corrected_mat_file_path:
+        source_data.update(
+            dict(
+                MotionCorrectedImaging=dict(
+                    file_path=str(motion_corrected_mat_file_path),
+                    timestamps_file_path=str(timestamps_mat_file_path),
+                )
+            )
+        )
+        reward_trials_indices = None or reward_trials_indices
+        conversion_options.update(
+            dict(MotionCorrectedImaging=dict(stub_test=stub_test, reward_trials_indices=reward_trials_indices))
+        )
+
+    # Add Segmentation
+    if segmentation_mat_file_path:
+        source_data.update(dict(Segmentation=dict(file_path=str(segmentation_mat_file_path))))
+        conversion_options.update(dict(Segmentation=dict(stub_test=stub_test)))
+
+    converter = AStOphysNWBConverter(source_data=source_data)
+
+    # Add datetime to conversion
+    metadata = converter.get_metadata()
+
+    # Update default metadata with the editable in the corresponding yaml file
+    # editable_metadata_path = Path(__file__).parent / "metadata" / "general_metadata.yaml"
+    # editable_metadata = load_dict_from_file(editable_metadata_path)
+    # metadata = dict_deep_update(metadata, editable_metadata)
+
+    converter.run_conversion(
+        nwbfile_path=str(nwbfile_path),
+        metadata=metadata,
+        conversion_options=conversion_options,
+        overwrite=True,
+    )
+
+
+if __name__ == "__main__":
+    # Parameters for converting a single session
+    stub_test = True
+
+    # Run conversion for a single session
+    session_to_nwb(
+        nwbfile_path="/Users/weian/catalystneuro/demo_notebooks/C6-J588-Disc5.nwb",
+        miniscope_folder_path="/Volumes/t7-ssd/Miniscope/C6-J588_Disc5",
+        processed_miniscope_avi_file_path="/Volumes/t7-ssd/Miniscope/C6-J588_Disc5_msCamAll_ffd.avi",
+        motion_corrected_mat_file_path="/Volumes/t7-ssd/Miniscope/C6-J588_Disc5_msCamComb_MC.mat",
+        timestamps_mat_file_path="/Volumes/t7-ssd/Miniscope/C6-J588_Disc5_timestampsAllCumulData.mat",
+        reward_trials_indices=[1, 3, 6, 9, 10, 12, 13, 15, 16, 20, 23, 24, 27, 28, 30],
+        segmentation_mat_file_path="/Volumes/t7-ssd/Miniscope/neuron.mat",
+        stub_test=stub_test,
+    )

--- a/src/tye_lab_to_nwb/ast_ophys/extractors/__init__.py
+++ b/src/tye_lab_to_nwb/ast_ophys/extractors/__init__.py
@@ -1,0 +1,2 @@
+from .cnmfe_matlab_segmentationextractor import CnmfeMatlabSegmentationExtractor
+from .motion_corrected_miniscope_imagingextractor import MotionCorrectedMiniscopeImagingExtractor

--- a/src/tye_lab_to_nwb/ast_ophys/extractors/cnmfe_matlab_segmentationextractor.py
+++ b/src/tye_lab_to_nwb/ast_ophys/extractors/cnmfe_matlab_segmentationextractor.py
@@ -1,0 +1,51 @@
+from pymatreader import read_mat
+from roiextractors import SegmentationExtractor
+from roiextractors.extraction_tools import PathType
+
+
+class CnmfeMatlabSegmentationExtractor(SegmentationExtractor):
+    """A SegmentationExtractor for matlab CNMF-E segmentation output."""
+
+    extractor_name = "CnmfeMatlabSegmentation"
+    mode = "file"
+
+    def __init__(self, file_path: PathType):
+        """Initialize a CnmfeMatlabSegmentationExtractor instance.
+
+        Parameters
+        ----------
+        file_path: str
+            The location of the folder containing  CNMF-E .mat output file.
+        """
+        super().__init__()
+        self.file_path = file_path
+
+        self._dataset_file = self._load_mat_file()
+
+        self._sampling_frequency = float(self._dataset_file["Fs"])
+        # image axis order should be height and width
+        self._image_size = (self._dataset_file["options"]["d1"], self._dataset_file["options"]["d2"])
+        self._num_frames = self._dataset_file["P"]["numFrames"]
+        self._roi_response_raw = self._dataset_file["C"].T
+        self._image_correlation = self._dataset_file["Cn"]
+        self._image_masks = self._transform_image_masks()
+
+    def _load_mat_file(self):
+        return read_mat(self.file_path)
+
+    def get_image_size(self):
+        return self._image_size
+
+    def get_num_frames(self):
+        return self._num_frames
+
+    def get_accepted_list(self):
+        return list(range(self.get_num_rois()))
+
+    def get_rejected_list(self):
+        return []
+
+    def _transform_image_masks(self):
+        image_masks = self._dataset_file["A"].toarray()
+        num_rois = self.get_num_rois()
+        return image_masks.reshape((*self._image_size, num_rois))

--- a/src/tye_lab_to_nwb/ast_ophys/extractors/motion_corrected_miniscope_imagingextractor.py
+++ b/src/tye_lab_to_nwb/ast_ophys/extractors/motion_corrected_miniscope_imagingextractor.py
@@ -1,0 +1,51 @@
+from typing import Tuple, List, Optional
+
+import numpy as np
+from lazy_ops import DatasetView
+from roiextractors import ImagingExtractor
+
+from neuroconv.utils import FilePathType
+
+
+class MotionCorrectedMiniscopeImagingExtractor(ImagingExtractor):
+    extractor_name = "MotionCorrectedMiniscopeImaging"
+
+    def __init__(self, file_path: FilePathType):
+        """
+        The ImagingExtractor for loading the motion corrected Miniscope video which is stored in a MATLAB (.mat) file.
+
+        Parameters
+        ----------
+        file_path: PathType
+           The path that points to the motion corrected Miniscope video saved as a Matlab file.
+        """
+        import h5py
+
+        super().__init__(file_path=file_path)
+
+        file = h5py.File(file_path, mode="r")
+        expected_struct_name = "Mr_8bit"
+        assert expected_struct_name in file.keys(), f"'{expected_struct_name}' is not in {file_path}."
+        self._video = DatasetView(file[expected_struct_name])
+        self._num_frames, self._width, self._height = self._video.shape
+        self._sampling_frequency = None
+
+    def get_image_size(self) -> Tuple[int, int]:
+        return self._height, self._width
+
+    def get_num_frames(self) -> int:
+        return self._num_frames
+
+    def get_sampling_frequency(self) -> float:
+        return self._sampling_frequency
+
+    def get_channel_names(self) -> List[str]:
+        return ["OpticalChannel"]
+
+    def get_num_channels(self) -> int:
+        return 1
+
+    def get_video(
+        self, start_frame: Optional[int] = None, end_frame: Optional[int] = None, channel: int = 0
+    ) -> np.ndarray:
+        return self._video.lazy_slice[start_frame:end_frame, ...].lazy_transpose(axis_order=(0, 2, 1)).dsetread()

--- a/src/tye_lab_to_nwb/ast_ophys/interfaces/__init__.py
+++ b/src/tye_lab_to_nwb/ast_ophys/interfaces/__init__.py
@@ -1,0 +1,3 @@
+from .cnmfe_matlab_segmentationinterface import CnmfeMatlabSegmentationSegmentationInterface
+from .motioncorrected_miniscope_imaginginterface import MotionCorrectedMiniscopeImagingInterface
+from .processed_miniscope_imaginginterface import ProcessedMiniscopeImagingInterface

--- a/src/tye_lab_to_nwb/ast_ophys/interfaces/cnmfe_matlab_segmentationinterface.py
+++ b/src/tye_lab_to_nwb/ast_ophys/interfaces/cnmfe_matlab_segmentationinterface.py
@@ -1,0 +1,24 @@
+from neuroconv.datainterfaces.ophys.basesegmentationextractorinterface import BaseSegmentationExtractorInterface
+from neuroconv.utils import FilePathType
+from tye_lab_to_nwb.ast_ophys.extractors.cnmfe_matlab_segmentationextractor import CnmfeMatlabSegmentationExtractor
+
+
+class CnmfeMatlabSegmentationSegmentationInterface(BaseSegmentationExtractorInterface):
+    """Data interface for constrained non-negative matrix factorization (CNMFE) segmentation extractor."""
+
+    Extractor = CnmfeMatlabSegmentationExtractor
+
+    def __init__(self, file_path: FilePathType, verbose: bool = True):
+        super().__init__(file_path=file_path)
+        self.verbose = verbose
+
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+
+        # Use the same device as for imaging
+        device_metadata = metadata["Ophys"]["Device"][0]
+        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
+        device_metadata.update(name="Miniscope")
+        imaging_plane_metadata.update(device="Miniscope")
+
+        return metadata

--- a/src/tye_lab_to_nwb/ast_ophys/interfaces/motioncorrected_miniscope_imaginginterface.py
+++ b/src/tye_lab_to_nwb/ast_ophys/interfaces/motioncorrected_miniscope_imaginginterface.py
@@ -5,10 +5,8 @@ import numpy as np
 import pandas as pd
 from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
 from neuroconv.tools.roiextractors import get_nwb_imaging_metadata
-from neuroconv.utils import FilePathType, dict_deep_update
+from neuroconv.utils import ArrayType, FilePathType, dict_deep_update
 from pynwb import NWBFile
-
-from neuroconv.utils import ArrayType
 
 from tye_lab_to_nwb.ast_ophys.extractors.motion_corrected_miniscope_imagingextractor import (
     MotionCorrectedMiniscopeImagingExtractor,

--- a/src/tye_lab_to_nwb/ast_ophys/interfaces/motioncorrected_miniscope_imaginginterface.py
+++ b/src/tye_lab_to_nwb/ast_ophys/interfaces/motioncorrected_miniscope_imaginginterface.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+from typing import Optional, List
+
+import numpy as np
+import pandas as pd
+from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
+from neuroconv.tools.roiextractors import get_nwb_imaging_metadata
+from neuroconv.utils import FilePathType, dict_deep_update
+from pynwb import NWBFile
+
+from neuroconv.utils import ArrayType
+
+from tye_lab_to_nwb.ast_ophys.extractors.motion_corrected_miniscope_imagingextractor import (
+    MotionCorrectedMiniscopeImagingExtractor,
+)
+from tye_lab_to_nwb.ast_ophys.tools import load_timestamps_from_mat, add_processed_one_photon_series
+
+
+class MotionCorrectedMiniscopeImagingInterface(BaseImagingExtractorInterface):
+    """Data Interface for MotionCorrectedMiniscopeImagingExtractor."""
+
+    Extractor = MotionCorrectedMiniscopeImagingExtractor
+
+    def __init__(
+        self,
+        file_path: FilePathType,
+        timestamps_file_path: FilePathType,
+    ):
+        """
+        Initialize reading the motion corrected Miniscope imaging data.
+
+        Parameters
+        ----------
+        file_path : FilePathType
+            The path that points to the motion corrected miniscope mat file.
+        """
+
+        self.timestamps_file_path = Path(timestamps_file_path)
+        self._timestamps_arr = load_timestamps_from_mat(self.timestamps_file_path)
+
+        super().__init__(file_path=file_path)
+
+    def get_original_timestamps(self) -> np.ndarray:
+        frames = load_timestamps_from_mat(self.timestamps_file_path)
+        # also shift to start from zero beacuse of matlab start from 1.0
+        frames = frames[~np.isnan(frames[:, 5]), 4] - 1
+        timestamps = frames / self.imaging_extractor.get_sampling_frequency()
+        return timestamps
+
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+
+        default_metadata = get_nwb_imaging_metadata(self.imaging_extractor, photon_series_type="OnePhotonSeries")
+        metadata = dict_deep_update(metadata, default_metadata)
+        metadata["Ophys"].pop("TwoPhotonSeries", None)
+
+        device_metadata = metadata["Ophys"]["Device"][0]
+        device_metadata.update(name="Miniscope")
+        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
+        imaging_plane_name = imaging_plane_metadata["name"]
+        imaging_plane_metadata.update(device="Miniscope")
+        one_photon_series_metadata = metadata["Ophys"]["OnePhotonSeries"][0]
+        one_photon_series_metadata.update(
+            name="OnePhotonSeriesMotionCorrected",
+            imaging_plane=imaging_plane_name,
+            description="The motion corrected imaging data from one-photon excitation microscopy.",
+        )
+
+        return metadata
+
+    def get_metadata_schema(self) -> dict:
+        metadata_schema = super().get_metadata_schema(photon_series_type="OnePhotonSeries")
+        metadata_schema["properties"]["Ophys"]["properties"]["definitions"]["Device"]["additionalProperties"] = True
+        return metadata_schema
+
+    def add_trials(
+        self,
+        nwbfile: NWBFile,
+        reward_trials_indices: Optional[List[int]] = None,
+    ):
+        trial_frame_times = pd.DataFrame(self._timestamps_arr)
+        trial_frame_times = trial_frame_times.dropna()
+
+        trial_frame_times_values = trial_frame_times.groupby(2).aggregate({4: ["min", "max"]}).values
+        # shift to zero because matlab starts from 1
+        trial_frame_times_values -= 1
+        # frame to time
+        trial_frame_times_values /= self.imaging_extractor.get_sampling_frequency()
+
+        for trial_frame_times_value in trial_frame_times_values:
+            nwbfile.add_trial(
+                start_time=trial_frame_times_value[0],
+                stop_time=trial_frame_times_value[1],
+            )
+
+        num_trials = trial_frame_times_values.shape[0]
+        if reward_trials_indices is not None:
+            trial_types = [
+                "Reward" if (trial_ind + 1) in reward_trials_indices else "Shock" for trial_ind in range(num_trials)
+            ]
+            nwbfile.add_trial_column(
+                name="trial_type",
+                description="Defines whether the trial was reward or shock.",
+                data=trial_types,
+            )
+
+        return nwbfile
+
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: Optional[dict] = None,
+        stub_test: bool = False,
+        stub_frames: int = 100,
+        reward_trials_indices: Optional[ArrayType] = None,
+    ):
+        imaging_extractor = self.imaging_extractor
+        timestamps = self.get_original_timestamps()
+        if stub_test:
+            stub_frames = min([stub_frames, self.imaging_extractor.get_num_frames()])
+            imaging_extractor = self.imaging_extractor.frame_slice(start_frame=0, end_frame=stub_frames)
+            timestamps = timestamps[:stub_frames]
+
+        self.add_trials(nwbfile=nwbfile, reward_trials_indices=reward_trials_indices)
+
+        add_processed_one_photon_series(
+            nwbfile=nwbfile, metadata=metadata, imaging=imaging_extractor, timestamps=timestamps
+        )

--- a/src/tye_lab_to_nwb/ast_ophys/interfaces/processed_miniscope_imaginginterface.py
+++ b/src/tye_lab_to_nwb/ast_ophys/interfaces/processed_miniscope_imaginginterface.py
@@ -5,12 +5,8 @@ import numpy as np
 from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
 from pynwb import NWBFile
 from roiextractors.extractors.miniscopeimagingextractor.miniscopeimagingextractor import _MiniscopeImagingExtractor
-
-from neuroconv.utils import FilePathType
-
+from neuroconv.utils import FilePathType, dict_deep_update
 from neuroconv.tools.roiextractors import get_nwb_imaging_metadata
-
-from neuroconv.utils import dict_deep_update
 
 from tye_lab_to_nwb.ast_ophys.tools import load_timestamps_from_mat, add_processed_one_photon_series
 

--- a/src/tye_lab_to_nwb/ast_ophys/interfaces/processed_miniscope_imaginginterface.py
+++ b/src/tye_lab_to_nwb/ast_ophys/interfaces/processed_miniscope_imaginginterface.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
+from pynwb import NWBFile
+from roiextractors.extractors.miniscopeimagingextractor.miniscopeimagingextractor import _MiniscopeImagingExtractor
+
+from neuroconv.utils import FilePathType
+
+from neuroconv.tools.roiextractors import get_nwb_imaging_metadata
+
+from neuroconv.utils import dict_deep_update
+
+from tye_lab_to_nwb.ast_ophys.tools import load_timestamps_from_mat, add_processed_one_photon_series
+
+
+class ProcessedMiniscopeImagingInterface(BaseImagingExtractorInterface):
+    """Data Interface for ProcessedMiniscopeImagingExtractor."""
+
+    Extractor = _MiniscopeImagingExtractor
+
+    def __init__(
+        self,
+        file_path: FilePathType,
+        timestamps_file_path: FilePathType,
+    ):
+        """
+        Initialize reading the processed Miniscope (first 3 frames is deleted for each trial) imaging data.
+
+        Parameters
+        ----------
+        file_path : FilePathType
+            The path that points to the processed miniscope video file.
+        """
+
+        self.timestamps_file_path = Path(timestamps_file_path)
+        self._timestamps_arr = load_timestamps_from_mat(self.timestamps_file_path)
+
+        super().__init__(file_path=file_path)
+
+    def get_original_timestamps(self) -> np.ndarray:
+        frames = load_timestamps_from_mat(self.timestamps_file_path)
+        # also shift to start from zero beacuse of matlab start from 1.0
+        frames = frames[~np.isnan(frames[:, 5]), 4] - 1
+        timestamps = frames / self.imaging_extractor.get_sampling_frequency()
+        return timestamps
+
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+
+        default_metadata = get_nwb_imaging_metadata(self.imaging_extractor, photon_series_type="OnePhotonSeries")
+        metadata = dict_deep_update(metadata, default_metadata)
+        metadata["Ophys"].pop("TwoPhotonSeries", None)
+
+        device_metadata = metadata["Ophys"]["Device"][0]
+        device_metadata.update(name="Miniscope")
+        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
+        imaging_plane_name = imaging_plane_metadata["name"]
+        imaging_plane_metadata.update(device="Miniscope")
+        one_photon_series_metadata = metadata["Ophys"]["OnePhotonSeries"][0]
+        one_photon_series_metadata.update(
+            name="OnePhotonSeriesProcessed",
+            imaging_plane=imaging_plane_name,
+            description="The processed imaging data from one-photon excitation microscopy."
+            "The first three frame for each trial was deleted from the original video snippets.",
+        )
+        return metadata
+
+    def get_metadata_schema(self) -> dict:
+        metadata_schema = super().get_metadata_schema(photon_series_type="OnePhotonSeries")
+        metadata_schema["properties"]["Ophys"]["properties"]["definitions"]["Device"]["additionalProperties"] = True
+        return metadata_schema
+
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: Optional[dict] = None,
+        stub_test: bool = False,
+        stub_frames: int = 100,
+    ):
+        imaging_extractor = self.imaging_extractor
+        timestamps = self.get_original_timestamps()
+        if stub_test:
+            stub_frames = min([stub_frames, self.imaging_extractor.get_num_frames()])
+            imaging_extractor = self.imaging_extractor.frame_slice(start_frame=0, end_frame=stub_frames)
+            timestamps = timestamps[:stub_frames]
+
+        add_processed_one_photon_series(
+            nwbfile=nwbfile,
+            metadata=metadata,
+            photon_series_index=2,
+            imaging=imaging_extractor,
+            timestamps=timestamps,
+        )

--- a/src/tye_lab_to_nwb/ast_ophys/requirements.txt
+++ b/src/tye_lab_to_nwb/ast_ophys/requirements.txt
@@ -1,0 +1,2 @@
+pymatreader>=0.0.32
+neuroconv[miniscope]

--- a/src/tye_lab_to_nwb/ast_ophys/tools/__init__.py
+++ b/src/tye_lab_to_nwb/ast_ophys/tools/__init__.py
@@ -1,0 +1,2 @@
+from .timestamps import load_timestamps_from_mat
+from .add_photon_series_to_processing import add_processed_one_photon_series

--- a/src/tye_lab_to_nwb/ast_ophys/tools/add_photon_series_to_processing.py
+++ b/src/tye_lab_to_nwb/ast_ophys/tools/add_photon_series_to_processing.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+import numpy as np
+from hdmf.backends.hdf5 import H5DataIO
+from neuroconv.tools import get_module
+from neuroconv.tools.roiextractors import add_imaging_plane
+from neuroconv.tools.roiextractors.imagingextractordatachunkiterator import ImagingExtractorDataChunkIterator
+from pynwb import NWBFile
+from pynwb.ophys import OnePhotonSeries
+from roiextractors import ImagingExtractor
+
+
+def add_processed_one_photon_series(
+    nwbfile: NWBFile,
+    imaging: ImagingExtractor,
+    timestamps: np.ndarray,
+    photon_series_index: Optional[int] = 1,
+    metadata: Optional[dict] = None,
+):
+    # add the same imaging plane as for raw OnePhotonSeries
+    add_imaging_plane(nwbfile=nwbfile, metadata=metadata, imaging_plane_index=0)
+    imaging_plane_name = metadata["Ophys"]["ImagingPlane"][0]["name"]
+    imaging_plane = nwbfile.get_imaging_plane(imaging_plane_name)
+
+    photon_series_kwargs = dict()
+    photon_series_kwargs.update(
+        name=metadata["Ophys"]["OnePhotonSeries"][photon_series_index]["name"],
+        description=metadata["Ophys"]["OnePhotonSeries"][photon_series_index]["description"],
+        imaging_plane=imaging_plane,
+        # H5DataIO wrap should be eventually removed
+        data=H5DataIO(data=ImagingExtractorDataChunkIterator(imaging_extractor=imaging), compression=True),
+        timestamps=H5DataIO(data=timestamps, compression=True),
+        dimension=imaging.get_image_size()[::-1],
+        unit="n.a.",
+    )
+
+    one_photon_series = OnePhotonSeries(**photon_series_kwargs)
+    ophys = get_module(nwbfile=nwbfile, name="ophys", description="contains optical physiology processed data")
+    ophys.add(one_photon_series)

--- a/src/tye_lab_to_nwb/ast_ophys/tools/timestamps.py
+++ b/src/tye_lab_to_nwb/ast_ophys/tools/timestamps.py
@@ -1,0 +1,8 @@
+from neuroconv.utils import FilePathType
+from pymatreader import read_mat
+
+
+def load_timestamps_from_mat(file_path: FilePathType):
+    mat_file = read_mat(str(file_path))
+    assert "timestampsMsAllCumul" in mat_file, f"Unable to find the expected 'timestampsMsAllCumul' in {file_path}"
+    return mat_file["timestampsMsAllCumul"]


### PR DESCRIPTION
- [Documentation](https://docs.google.com/document/d/1vgltTGQ7ekQcvnIhzXXt0T3xYcga_52r/edit) about the dataset

TODO:

- [x] Add raw Miniscope data using `MiniscopeConverter` to acquisition
- [x] Add interface for processed Miniscope data ("C6-J588_Disc5_msCamAll_ffd.mat"): the raw Miniscope video snippets are concatenated together into a single .avi file. The first frames of every trial is removed. Note that the raw Miniscope video shape (height, width) is `(480, 752)` while this AVI is `(240, 376)` -> added to processing `nwbfile.processing["ophys"]["OnePhotonSeriesProcessed"]`
- [x] Add extractor and interface for the motion corrected Miniscope data ("C6-J588_Disc5_msCamComb_MC"): the processed Miniscope data was motion corrected and saved as a MATLAB file. ->  added to processing 
`nwbfile.processing["ophys"]["OnePhotonSeriesMotionCorrected"]`
- [x] Add trials from `C6-J588_Disc5_timestampsAllCumulData.mat`
- [x] Add custom mat file with CNMFE segmentation data `C6J588_Disc5_msCamComb_MC_curated_20220605_1722.mat` (+ link issue, first the neuron struct has to be saved into a new Matlab file to be able to open in Python) 
- [x] Upload prototype data

- [ ] Confirm sampling rate of processed data which is 30.0 when the video is opened in OpenCV (raw data, segmented data is fps 15.0)
- [ ] Double check timestamps are adjusted correctly
- [ ] Add metadata
- [ ] Add convert_all_sessions script after the single session convert script is finalized
- [ ] Run nwbinspector on fully converted data

