### PR TITLE
Update fiber photometry pipeline

### DIFF
--- a/src/tye_lab_to_nwb/fiber_photometry/convert_all_sessions.py
+++ b/src/tye_lab_to_nwb/fiber_photometry/convert_all_sessions.py
@@ -1,0 +1,64 @@
+import ast
+from pathlib import Path
+from typing import Optional
+
+from neuroconv.utils import FilePathType
+from tye_lab_to_nwb.fiber_photometry.convert_session import session_to_nwb
+from tye_lab_to_nwb.tools import read_session_config, parallel_execute
+
+
+def parallel_convert_sessions(
+    excel_file_path: FilePathType,
+    num_parallel_jobs: Optional[int] = 1,
+):
+    """
+    Parallel converts NWB files.
+
+    Parameters
+    ----------
+    excel_file_path : FilePathType
+        The path to the Excel (.xlsx) file that contains the parameters for converting the sessions.
+        The number of rows in the file corresponds to the number of sessions that will be converted.
+        The folder path to the ecephys recording and the file path to the NWB file are required values for each row.
+    num_parallel_jobs: int, optional
+        The number of parallel converted sessions. The default is to convert one session at a time.
+        When not specified (num_parallel_jobs=None) it is set to use all available CPUs.
+    stub_test: bool, optional
+        For testing purposes, when stub_test=True only writes a subset of ecephys and plexon data.
+        Default is to write the whole ecephys recording and plexon data to the file.
+    """
+
+    config = read_session_config(excel_file_path=excel_file_path)
+
+    kwargs_list = []
+    for row_ind, row in config.iterrows():
+        subject_metadata = dict()
+        for subject_field in ["sex", "subject_id", "age", "genotype", "strain"]:
+            if config[subject_field][row_ind]:
+                subject_metadata[subject_field] = str(config[subject_field][row_ind])
+        kwargs_list.append(
+            dict(
+                nwbfile_path=row["nwbfile_path"],
+                data_file_path=row["data_file_path"],
+                session_start_time=row["session_start_time"],
+                subject_metadata=subject_metadata,
+            )
+        )
+    parallel_execute(
+        session_to_nwb_function=session_to_nwb,
+        kwargs_list=kwargs_list,
+        num_parallel_jobs=num_parallel_jobs,
+    )
+
+
+if __name__ == "__main__":
+    # Parameters for converting sessions in parallel
+    # The path to the Excel (.xlsx) file that contains the file paths for each data stream.
+    # The number of rows in the file corresponds to the number of sessions that can be converted.
+    excel_file_path = Path("/Volumes/t7-ssd/Hao_NWB/recording/session_config.xlsx")
+
+    # Run conversion for all sessions that are in the configuration file
+    parallel_convert_sessions(
+        excel_file_path=excel_file_path,
+        num_parallel_jobs=3,  # defines the number of sessions that will be converted in parallel.
+    )

--- a/src/tye_lab_to_nwb/fiber_photometry/fiber_photometry_notes.md
+++ b/src/tye_lab_to_nwb/fiber_photometry/fiber_photometry_notes.md
@@ -1,0 +1,12 @@
+# Conversion notes
+
+## Run conversion for multiple sessions in parallel
+
+The `convert_all_sessions.py` conversion script takes an Excel (.xlsx) file as an input
+which contain all the necessary information to convert each session. The number of rows in the file
+correspond to the number of sessions that will be converted.
+
+The columns in the selected Excel (.xlsx) file should be named as:
+- "`nwbfile_path`": The file path where the NWB file will be created. (e.g. "test.nwb")
+- "`data_file_path`": The path that points to the .csv file containing the photometry intensity values.
+- "`session_start_time`": The recording start time for the photometry session in YYYY-MM-DDTHH:MM:SS format (e.g. 2023-08-21T15:30:00).

--- a/src/tye_lab_to_nwb/fiber_photometry/fiberphotometrydatainterface.py
+++ b/src/tye_lab_to_nwb/fiber_photometry/fiberphotometrydatainterface.py
@@ -87,18 +87,12 @@ class FiberPhotometryInterface(BaseDataInterface):
         """
         self.photometry_dataframe[column] = aligned_timestamps
 
-    def run_conversion(
+    def add_to_nwbfile(
         self,
-        nwbfile_path: OptionalFilePathType = None,
-        nwbfile: Optional[NWBFile] = None,
+        nwbfile: NWBFile,
         metadata: Optional[dict] = None,
         stub_test: bool = False,
         overwrite: bool = False,
     ):
-        with make_or_load_nwbfile(
-            nwbfile_path=nwbfile_path, nwbfile=nwbfile, metadata=metadata, overwrite=overwrite, verbose=self.verbose
-        ) as nwbfile_out:
-            add_events_from_photometry(
-                photometry_dataframe=self.photometry_dataframe, nwbfile=nwbfile_out, metadata=metadata
-            )
-            add_photometry(photometry_dataframe=self.photometry_dataframe, nwbfile=nwbfile_out, metadata=metadata)
+        add_events_from_photometry(photometry_dataframe=self.photometry_dataframe, nwbfile=nwbfile, metadata=metadata)
+        add_photometry(photometry_dataframe=self.photometry_dataframe, nwbfile=nwbfile, metadata=metadata)

--- a/src/tye_lab_to_nwb/fiber_photometry/metadata/general_metadata.yaml
+++ b/src/tye_lab_to_nwb/fiber_photometry/metadata/general_metadata.yaml
@@ -4,9 +4,8 @@ NWBFile:
   lab: Tye
   experimenter:
     - Li, Hao
-  related_publications: https://doi.org/10.1038/s41586-022-04964-y
+  related_publications:
+    - https://doi.org/10.1038/s41586-022-04964-y
 Subject:
   species: Mus musculus
   age: P8W/P20W # male and female mice between the ages of 8-20 weeks were used for all experiments
-  sex: U # "M" is for male, "F" is for female (for this session it is unknown)
-  #strain: C57BL/6J # the strain of the mouse for this session

--- a/src/tye_lab_to_nwb/fiber_photometry/requirements.txt
+++ b/src/tye_lab_to_nwb/fiber_photometry/requirements.txt
@@ -1,4 +1,3 @@
-neuroconv
 hdmf==3.6.1 # Pin until https://github.com/catalystneuro/ndx-photometry/issues/8 is resolved
 ndx-photometry==0.2.0
 ndx-events==0.2.0

--- a/src/tye_lab_to_nwb/fiber_photometry/requirements.txt
+++ b/src/tye_lab_to_nwb/fiber_photometry/requirements.txt
@@ -2,3 +2,4 @@ git+https://github.com/catalystneuro/neuroconv.git@36fe8ba02c036e715a915ee660793
 hdmf==3.6.1 # Pin until https://github.com/catalystneuro/ndx-photometry/issues/8 is resolved
 ndx-photometry==0.2.0
 ndx-events==0.2.0
+openpyxl>=3.1.2

--- a/src/tye_lab_to_nwb/fiber_photometry/requirements.txt
+++ b/src/tye_lab_to_nwb/fiber_photometry/requirements.txt
@@ -1,3 +1,4 @@
+git+https://github.com/catalystneuro/neuroconv.git@36fe8ba02c036e715a915ee66079391a50536fb2#egg=neuroconv
 hdmf==3.6.1 # Pin until https://github.com/catalystneuro/ndx-photometry/issues/8 is resolved
 ndx-photometry==0.2.0
 ndx-events==0.2.0

--- a/src/tye_lab_to_nwb/fiber_photometry/requirements.txt
+++ b/src/tye_lab_to_nwb/fiber_photometry/requirements.txt
@@ -1,2 +1,4 @@
-git+https://github.com/catalystneuro/ndx-photometry
-ndx-events>=0.2.0
+neuroconv
+hdmf==3.6.1 # Pin until https://github.com/catalystneuro/ndx-photometry/issues/8 is resolved
+ndx-photometry==0.2.0
+ndx-events==0.2.0

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_requirements.txt
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/catalystneuro/neuroconv@add_ignore_timestamps_errors_to_interface#egg=neuroconv
+git+https://github.com/catalystneuro/neuroconv.git@36fe8ba02c036e715a915ee66079391a50536fb2#egg=neuroconv
 neuroconv[openephys,plexon,video]
 git+https://github.com/neuralensemble/python-neo@master
 ndx_pose>=0.1.1


### PR DESCRIPTION
Fix #37 to work in updated neuroconv environment
resolve #25 by pinning `ndx-photometry==0.2.0`
- pins hdmf==3.6.1 until https://github.com/catalystneuro/ndx-photometry/issues/8 is resolved
- add [convert_all_sessions.py ](https://github.com/catalystneuro/tye-lab-to-nwb/blob/cf023a5815f79077e3a101715f16142ecf972e69/src/tye_lab_to_nwb/fiber_photometry/convert_all_sessions.py)
- add [fiber_photometry_notes.md](https://github.com/catalystneuro/tye-lab-to-nwb/blob/cf023a5815f79077e3a101715f16142ecf972e69/src/tye_lab_to_nwb/fiber_photometry/fiber_photometry_notes.md)