### PR TITLE
Remove `ignore_timestamps_errors` flag

### DIFF
--- a/src/tye_lab_to_nwb/ast_ecephys/convert_session.py
+++ b/src/tye_lab_to_nwb/ast_ecephys/convert_session.py
@@ -3,9 +3,6 @@ from pathlib import Path
 from typing import Optional, Dict
 from warnings import warn
 
-from importlib.metadata import version
-from packaging.version import Version
-
 from nwbinspector import inspect_nwb
 from nwbinspector.inspector_tools import format_messages, save_report
 
@@ -63,8 +60,6 @@ def session_to_nwb(
 
     # Add Recording
     recording_source_data = dict(folder_path=str(ecephys_recording_folder_path), stream_name="Signals CH")
-    if Version(version("neo")) > Version("0.12.0"):
-        recording_source_data.update(ignore_timestamps_errors=True)
 
     source_data.update(dict(Recording=recording_source_data))
     conversion_options.update(dict(Recording=dict(stub_test=stub_test)))

--- a/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
+++ b/src/tye_lab_to_nwb/neurotensin_valence/neurotensin_valence_convert_session.py
@@ -1,6 +1,5 @@
 """Primary script to run to convert an entire session for of data using the NWBConverter."""
 import traceback
-from importlib.metadata import version
 from pathlib import Path
 from typing import Optional, Dict
 from warnings import warn
@@ -15,7 +14,6 @@ from neuroconv.utils import (
 )
 from nwbinspector import inspect_nwbfile
 from nwbinspector.inspector_tools import save_report, format_messages
-from packaging.version import Version
 
 from tye_lab_to_nwb.neurotensin_valence import NeurotensinValenceNWBConverter
 
@@ -74,8 +72,6 @@ def session_to_nwb(
     # Add Recording
     if ecephys_recording_folder_path:
         recording_source_data = dict(folder_path=str(ecephys_recording_folder_path), stream_name="Signals CH")
-        if Version(version("neo")) > Version("0.12.0"):
-            recording_source_data.update(ignore_timestamps_errors=True)
 
         source_data.update(dict(Recording=recording_source_data))
         conversion_options.update(dict(Recording=dict(stub_test=stub_test)))


### PR DESCRIPTION
Using `ignore_timestamps_errors` currently does not guarantee that data has no gaps in it. 
https://github.com/NeuralEnsemble/python-neo/issues/1336
I think it is better to remove completely and if we see this error we can turn it on for investigating. 
